### PR TITLE
Make use of InitializeASI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${aw2-cmdline-plugin_SOURCES
 
 
 target_compile_features(aw2-cmdline-plugin PUBLIC
-	cxx_std_20
+	cxx_std_23
 )
 
 target_compile_options(aw2-cmdline-plugin PUBLIC

--- a/cmake.toml
+++ b/cmake.toml
@@ -78,7 +78,7 @@ include-directories = [
     "plugin/"
 ]
 compile-options = ["/GS-", "/bigobj", "/EHa", "/MP"]
-compile-features = ["cxx_std_20"]
+compile-features = ["cxx_std_23"]
 compile-definitions = []
 link-libraries = [
     "kananlib"

--- a/plugin/Main.cpp
+++ b/plugin/Main.cpp
@@ -45,7 +45,7 @@ void startup_thread() {
 bool IsUALPresent() {
     for (const auto& entry : std::stacktrace::current()) {
         HMODULE hModule = NULL;
-        if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)entry.native_handle(), &hModule)) {
+        if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCSTR)entry.native_handle(), &hModule)) {
             if (GetProcAddress(hModule, "IsUltimateASILoader") != NULL)
                 return true;
         }

--- a/plugin/Main.cpp
+++ b/plugin/Main.cpp
@@ -5,6 +5,8 @@
 #include <utility/Patch.hpp>
 #include <utility/RTTI.hpp>
 
+#include <stacktrace>
+
 bool ret1() {
     return true;
 }
@@ -40,30 +42,31 @@ void startup_thread() {
     SPDLOG_INFO("Patched vtable[2] to 0x{:X}", vtp[2]);
 }
 
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
-    if (ul_reason_for_call == DLL_PROCESS_ATTACH) {
-        if (g_already_patched) {
-            return TRUE;
+bool IsUALPresent() {
+    for (const auto& entry : std::stacktrace::current()) {
+        HMODULE hModule = NULL;
+        if (GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)entry.native_handle(), &hModule)) {
+            if (GetProcAddress(hModule, "IsUltimateASILoader") != NULL)
+                return true;
         }
-
-        g_already_patched = true;
-        startup_thread();
-        //CreateThread(nullptr, 0, (LPTHREAD_START_ROUTINE)startup_thread, nullptr, 0, nullptr);
     }
-
-    return TRUE;
+    return false;
 }
 
 extern "C" __declspec(dllexport) void InitializeASI()
 {
-    __try
-    {
-        if (!g_already_patched) {
-            g_already_patched = true;
-            startup_thread();
-        }
+    if (g_already_patched) {
+        return;
     }
-    __except ((GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION) ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
-    {
+
+    g_already_patched = true;
+    startup_thread();
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved) {
+    if (ul_reason_for_call == DLL_PROCESS_ATTACH) {
+        if (!IsUALPresent()) { InitializeASI(); }
     }
+
+    return TRUE;
 }


### PR DESCRIPTION
Currently DllMain is naturally loaded earlier, so InitializeASI doesn't do anything useful. I've written a check for asi loader using std::stacktrace(c++23), this will prevent loading from dllmain with UAL, and will remain compatible with manual injection/different loading methods.